### PR TITLE
Support for the same month to default on the 2nd calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ export default function YourComponent() {
 | `labels`               | `Labels`                         | -                                       | Customize labels used in UI (Apply, Cancel, Start Date, End Date etc.) |
 | `hideDefaultRanges`    | `boolean`                        | false                                   | Option to hide default predefined ranges.                              |
 | `hideOutsideMonthDays` | `boolean`                        | true                                    | Option to hide days outside the current month.                         |
+| `initialEndOnRight` | `boolean`                        | false                                    | Option to default the values to the 2nd calendar (the one on the right). This is useful for when the period is expected to be only extended on the from (left) side.                        |
 
 > Make sure to provide `initialDateRange` within the min and max date.
 

--- a/src/components/Sections.SingleCalender.tsx
+++ b/src/components/Sections.SingleCalender.tsx
@@ -27,6 +27,7 @@ type SingleCalenderProps = {
   locale?: Locale;
 
   hideOutsideMonthDays?: boolean;
+  initialEndOnRight?: boolean;
 };
 
 export const SingleCalender = ({
@@ -36,6 +37,7 @@ export const SingleCalender = ({
   commonProps,
   locale,
   hideOutsideMonthDays,
+  initialEndOnRight,
 }: SingleCalenderProps) => {
   const canNavigateBack = !isSameMonth(firstMonth, commonProps.minDate);
   const canNavigateForward = !isSameMonth(firstMonth, commonProps.maxDate);
@@ -53,7 +55,7 @@ export const SingleCalender = ({
       <Grid2 xs="auto" container direction={"column"}>
         <Month
           {...commonProps}
-          currentDate={firstMonth}
+          currentDate={initialEndOnRight ? secondMonth : firstMonth}
           otherDate={secondMonth}
           setMonth={handleSetSingleMonth}
           navState={[canNavigateBack, canNavigateForward]}

--- a/src/components/Sections.tsx
+++ b/src/components/Sections.tsx
@@ -55,6 +55,7 @@ type SectionsProps = {
   };
   onCloseCallback?: () => void;
   footerRequired?: boolean;
+  initialEndOnRight?: boolean;
 };
 
 export const Sections = (props: SectionsProps) => {
@@ -81,6 +82,7 @@ export const Sections = (props: SectionsProps) => {
     RangeSeparatorIcons,
     onCloseCallback,
     footerRequired,
+    initialEndOnRight,
   } = props;
 
   const { startDate, endDate } = dateRange;
@@ -271,6 +273,7 @@ export const Sections = (props: SectionsProps) => {
             commonProps={commonProps}
             hideOutsideMonthDays={hideOutsideMonthDays}
             locale={locale}
+            initialEndOnRight={initialEndOnRight}
           />
         </Grid2>
 

--- a/src/hooks/useDateRangePicker.ts
+++ b/src/hooks/useDateRangePicker.ts
@@ -34,6 +34,7 @@ export const useDateRangePicker = (props: useDateRangePickerProps) => {
     maxDate,
     definedRanges = getDefaultRanges(new Date(), props.locale),
     locale,
+    initialEndOnRight,
   } = props;
 
   // !Assign starting states
@@ -43,7 +44,8 @@ export const useDateRangePicker = (props: useDateRangePickerProps) => {
   const [initialFirstMonth, initialSecondMonth] = getValidatedMonths(
     initialDateRange || {},
     minValidDate,
-    maxValidDate
+    maxValidDate,
+    initialEndOnRight || false
   );
   const [dateRange, setDateRange] = useState<DateRange>({
     ...initialDateRange,

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -39,6 +39,8 @@ export type PickerProps = {
 
   hideDefaultRanges?: boolean;
   hideOutsideMonthDays?: boolean;
+
+  initialEndOnRight?: boolean;
 };
 
 export type ModalCustomProps = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -117,13 +117,20 @@ export const parseOptionalDate = (
 export const getValidatedMonths = (
   range: DateRange,
   minDate: Date,
-  maxDate: Date
+  maxDate: Date,
+  initialEndOnRight: boolean
 ) => {
   const { startDate, endDate } = range;
   if (startDate && endDate) {
     const newStart = max([startDate, minDate]);
     const newEnd = min([endDate, maxDate]);
 
+    if (initialEndOnRight) {
+      return [
+        isSameMonth(newStart, newEnd) ? addMonths(newStart, -1) : newStart,
+        isSameMonth(newStart, newEnd) ? newStart : newEnd,
+      ];
+    }
     return [
       newStart,
       isSameMonth(newStart, newEnd) ? addMonths(newStart, 1) : newEnd,


### PR DESCRIPTION
If both of the initial dates are from the same month the calendar will always default them to the left (first) calendar. This is not very useful if all selectable periods are up to today and the initial period is in the current month. For those use cases the preferred behavior would be to have the current month on the right. This change introduces a new parameter `initialEndOnRight` which allows the users to choose the behavior based on their needs.

Example usage:
```javascript
<PickerModal
      initialEndOnRight
      initialDateRange={{
        startDate: new Date(startDateParam),
        endDate: new Date(endDateParam),
      }}
      customProps={{
        onSubmit: (range: DateRange) => handleSetDateRangeOnSubmit(range),
        onCloseCallback: handleClose,
      }}
      modalProps={{
        open: !!anchorEl,
        anchorEl,
        onClose: handleClose,
        anchorOrigin: {
          vertical: "bottom",
          horizontal: "left",
        },
      }}
    />
```

Opens the dialog like this:
<img width="704" alt="Screenshot 2025-05-30 at 12 28 39 PM" src="https://github.com/user-attachments/assets/84b2787c-57c2-482a-aa97-7291955786f9" />

